### PR TITLE
keep kube_green_ metrics

### DIFF
--- a/addons/prometheus-operator/kube-green/resources/servicemonitor.yaml
+++ b/addons/prometheus-operator/kube-green/resources/servicemonitor.yaml
@@ -11,7 +11,7 @@ spec:
     scrapeTimeout: 30s
     metricRelabelings:
     - action: keep
-      regex: controller_runtime.*
+      regex: (controller_runtime|kube_green_).*
       sourceLabels:
       - __name__
   selector:

--- a/modules/scheduling/kube-green/CHANGELOG.md
+++ b/modules/scheduling/kube-green/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- ServiceMonitor keep also metrics with prefix `kube_green`
+
 ## v1.25.0
 
 - no changes

--- a/modules/scheduling/kube-green/README.md
+++ b/modules/scheduling/kube-green/README.md
@@ -24,7 +24,7 @@ The module will install all its component inside the `kube-green-system` namespa
 default **ports**:
 
 - kube-green:
-  - **11230**for exposing the webhook endpoint, the api-server must reach this port for avoiding timeout errors on
+  - **11230** for exposing the webhook endpoint, the api-server must reach this port for avoiding timeout errors on
 		CRDs creation
   - **11231** for exposing the metrics endpoint
   - **11232** expose the health probe endpoint for kubernetes


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

## What this PR is for?

kube-green from version [0.5.0](https://github.com/kube-green/kube-green/releases/tag/v0.5.0) exposes some custom metrics with prefix `kube_green`. I change the ServiceMonitor to keep also this metrics.

<!--
Describe what this PR is trying to achieve, for example is this a PR that fix an open issue? Is for a new feature? etc.
-->

